### PR TITLE
Removed semi-colons from command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ If you'd like to install locally, first ensure that Pandoc is installed and avai
 
 ```
 $ pip install -r requirements.txt
-DEBUG=True; TUMBLR_API_KEY="<API KEY HERE>"; python web.py
+DEBUG=True TUMBLR_API_KEY="<API KEY HERE>" python web.py
 ```
 


### PR DESCRIPTION
`DEBUG` and `TUMBLR_API_KEY` env-vars will _not_ be in the environment otherwise and api_key will not be set.
