### PR TITLE
Tags weren't really working

### DIFF
--- a/tumblr_to_ghost.py
+++ b/tumblr_to_ghost.py
@@ -9,7 +9,7 @@ import pandoc
 from unidecode import unidecode
 
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 API_URL = 'http://api.tumblr.com/v2/blog/{url}/{resource}?api_key={api_key}'


### PR DESCRIPTION
# What's changed
- The tag import wasn't really working, only importing tags for the last blog post, as there was a scope issue.
- Bumped the limit a bit, this took a long time for old tumblr blogs
- Removed the conversion to markdown. I'm more concerned about how my past blog posts look than whether they're in markdown. The conversion to markdown was inconsistent, put newlines everywhere, and generally not pretty.
- Did some more parsing on text titles (`'` should be `'`, not `&8217;`)
- Body parsing for links in create_body created a code block.
- Tag slugs are actually slugs.
